### PR TITLE
Feature/add fields and aliases

### DIFF
--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -4,6 +4,7 @@ import com.github.thesench.solr.dsl.stream.expr.evaluators.Evaluator;
 import com.github.thesench.solr.dsl.stream.expr.params.BatchSize;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
 import com.github.thesench.solr.dsl.stream.expr.params.FL;
+import com.github.thesench.solr.dsl.stream.expr.params.Field;
 import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
 import com.github.thesench.solr.dsl.stream.expr.params.On;
@@ -40,6 +41,32 @@ public class StreamDecorators {
         return new StreamExpression("cartesianProduct")
             .withParameter(incomingStream)
             .withParameter(fieldName)
+            .withParameter(productSort);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param field
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Field field) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(field.toString());
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param field
+     * @param productSort
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Field field, ProductSort productSort) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(field.toString())
             .withParameter(productSort);
     }
     

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -1,10 +1,12 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
 import com.github.thesench.solr.dsl.stream.expr.evaluators.Evaluator;
+import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
 import com.github.thesench.solr.dsl.stream.expr.params.BatchSize;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
 import com.github.thesench.solr.dsl.stream.expr.params.FL;
 import com.github.thesench.solr.dsl.stream.expr.params.Field;
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
 import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
 import com.github.thesench.solr.dsl.stream.expr.params.On;
@@ -14,6 +16,7 @@ import com.github.thesench.solr.dsl.stream.expr.params.Sort;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 
 public class StreamDecorators {
     private StreamDecorators() {}
@@ -320,6 +323,22 @@ public class StreamDecorators {
             .withParameter(stream);
         for (String field : fields) {
             selectStream.addParameter(field);
+        }
+        return selectStream;
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#select">Stream Decorator Reference: select</a>
+     * @param stream
+     * @param fields
+     * @return
+     */
+    public static StreamExpression select(StreamExpression stream, FieldOrAliasOrReplace... fields) {
+        StreamExpression selectStream = new StreamExpression("select")
+            .withParameter(stream);
+        for (FieldOrAliasOrReplace fieldOrAlias : fields) {
+            StreamExpressionParameter formattedField = fieldOrAlias.format(AliasType.AS);
+            selectStream.addParameter(formattedField);
         }
         return selectStream;
     }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Add.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Add.java
@@ -1,0 +1,100 @@
+package com.github.thesench.solr.dsl.stream.expr.evaluators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Add {
+    private Add() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param firstField
+     * @param secondField
+     * @param otherFields
+     * @return
+     */
+    public static NumberEvaluator add(FieldOrEvaluator firstField, FieldOrEvaluator secondField, FieldOrEvaluator... otherFields) {
+        StreamExpression evaluatorExpression = new NumberEvaluator("add")
+            .withParameter(firstField.toString())
+            .withParameter(secondField.toString());
+
+        for (FieldOrEvaluator field : otherFields) {
+            evaluatorExpression.addParameter(field.toString());
+        }
+
+        return (NumberEvaluator) evaluatorExpression;
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param fieldOrEvaluator
+     * @param value
+     * @return
+     */
+    public static NumberEvaluator add(FieldOrEvaluator fieldOrEvaluator, int value) {
+        return (NumberEvaluator) new NumberEvaluator("add")
+            .withParameter(fieldOrEvaluator)
+            .withParameter(Integer.toString(value));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param fieldOrEvaluator
+     * @param value
+     * @return
+     */
+    public static NumberEvaluator add(FieldOrEvaluator fieldOrEvaluator, double value) {
+        return (NumberEvaluator) new NumberEvaluator("add")
+            .withParameter(fieldOrEvaluator)
+            .withParameter(Double.toString(value));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param fieldOrEvaluator
+     * @param value
+     * @return
+     */
+    public static NumberEvaluator add(FieldOrEvaluator fieldOrEvaluator, float value) {
+        return (NumberEvaluator) new NumberEvaluator("add")
+            .withParameter(fieldOrEvaluator)
+            .withParameter(Float.toString(value));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param value
+     * @param fieldOrEvaluator
+     * @return
+     */
+    public static NumberEvaluator add(int value, FieldOrEvaluator fieldOrEvaluator) {
+        return (NumberEvaluator) new NumberEvaluator("add")
+            .withParameter(Integer.toString(value))
+            .withParameter(fieldOrEvaluator);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param value
+     * @param fieldOrEvaluator
+     * @return
+     */
+    public static NumberEvaluator add(double value, FieldOrEvaluator fieldOrEvaluator) {
+        return (NumberEvaluator) new NumberEvaluator("add")
+            .withParameter(Double.toString(value))
+            .withParameter(fieldOrEvaluator);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#add">Stream Evaluator Reference: add</a>
+     * @param value
+     * @param fieldOrEvaluator
+     * @return
+     */
+    public static NumberEvaluator add(float value, FieldOrEvaluator fieldOrEvaluator) {
+        return (NumberEvaluator) new NumberEvaluator("add")
+            .withParameter(Float.toString(value))
+            .withParameter(fieldOrEvaluator);
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/BooleanEvaluator.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/BooleanEvaluator.java
@@ -1,7 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
 public class BooleanEvaluator extends Evaluator {
-    public BooleanEvaluator(String value) {
-        super(value);
+    public BooleanEvaluator(String functionName) {
+        super(functionName);
     }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Div.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Div.java
@@ -1,0 +1,308 @@
+package com.github.thesench.solr.dsl.stream.expr.evaluators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.Field;
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
+
+public class Div {
+    private Div() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(Field firstValue, Field secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(secondValue);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(Field firstValue, NumberEvaluator secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(secondValue);
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(Field firstValue, int secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(Integer.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(Field firstValue, float secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(Float.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(Field firstValue, double secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(Double.toString(secondValue));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(NumberEvaluator firstValue, Field secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(secondValue);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(NumberEvaluator firstValue, NumberEvaluator secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(secondValue);
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(NumberEvaluator firstValue, int secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(Integer.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(NumberEvaluator firstValue, float secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(Float.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(NumberEvaluator firstValue, double secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(firstValue)
+            .withParameter(Double.toString(secondValue));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(int firstValue, Field secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Integer.toString(firstValue))
+            .withParameter(secondValue);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(int firstValue, NumberEvaluator secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Integer.toString(firstValue))
+            .withParameter(secondValue);
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(int firstValue, int secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Integer.toString(firstValue))
+            .withParameter(Integer.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(int firstValue, float secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Integer.toString(firstValue))
+            .withParameter(Float.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(int firstValue, double secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Integer.toString(firstValue))
+            .withParameter(Double.toString(secondValue));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(float firstValue, Field secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Float.toString(firstValue))
+            .withParameter(secondValue);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(float firstValue, NumberEvaluator secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Float.toString(firstValue))
+            .withParameter(secondValue);
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(float firstValue, int secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Float.toString(firstValue))
+            .withParameter(Integer.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(float firstValue, float secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Float.toString(firstValue))
+            .withParameter(Float.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(float firstValue, double secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Float.toString(firstValue))
+            .withParameter(Double.toString(secondValue));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(double firstValue, Field secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Double.toString(firstValue))
+            .withParameter(secondValue);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(double firstValue, NumberEvaluator secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Double.toString(firstValue))
+            .withParameter(secondValue);
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(double firstValue, int secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Double.toString(firstValue))
+            .withParameter(Integer.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(double firstValue, float secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Double.toString(firstValue))
+            .withParameter(Float.toString(secondValue));
+    }
+    
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#div">Stream Evaluator Reference: div</a>
+     * @param firstValue
+     * @param secondValue
+     * @return
+     */
+    public static NumberEvaluator div(double firstValue, double secondValue) {
+        return (NumberEvaluator) new NumberEvaluator("div")
+            .withParameter(Double.toString(firstValue))
+            .withParameter(Double.toString(secondValue));
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Div.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Div.java
@@ -1,7 +1,6 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
 import com.github.thesench.solr.dsl.stream.expr.params.Field;
-import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
 
 public class Div {
     private Div() {}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Eq.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Eq.java
@@ -1,0 +1,100 @@
+package com.github.thesench.solr.dsl.stream.expr.evaluators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Eq {
+    private Eq() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param firstValue
+     * @param secondValue
+     * @param otherValues
+     * @return
+     */
+    public static BooleanEvaluator eq(FieldOrEvaluator firstValue, FieldOrEvaluator secondValue, FieldOrEvaluator... otherValues) {
+        StreamExpression eqExpression = new BooleanEvaluator("eq")
+            .withParameter(firstValue)
+            .withParameter(secondValue);
+        
+        for (FieldOrEvaluator value : otherValues) {
+            eqExpression.addParameter(value);
+        }
+
+        return (BooleanEvaluator) eqExpression;
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param fieldOrEvaluator
+     * @param value
+     * @return
+     */
+    public static BooleanEvaluator eq(FieldOrEvaluator fieldOrEvaluator, int value) {
+        return (BooleanEvaluator) new BooleanEvaluator("eq")
+            .withParameter(fieldOrEvaluator)
+            .withParameter(Integer.toString(value));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param fieldOrEvaluator
+     * @param value
+     * @return
+     */
+    public static BooleanEvaluator eq(FieldOrEvaluator fieldOrEvaluator, double value) {
+        return (BooleanEvaluator) new BooleanEvaluator("eq")
+            .withParameter(fieldOrEvaluator)
+            .withParameter(Double.toString(value));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param fieldOrEvaluator
+     * @param value
+     * @return
+     */
+    public static BooleanEvaluator eq(FieldOrEvaluator fieldOrEvaluator, float value) {
+        return (BooleanEvaluator) new BooleanEvaluator("eq")
+            .withParameter(fieldOrEvaluator)
+            .withParameter(Float.toString(value));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param value
+     * @param fieldOrEvaluator
+     * @return
+     */
+    public static BooleanEvaluator eq(int value, FieldOrEvaluator fieldOrEvaluator) {
+        return (BooleanEvaluator) new BooleanEvaluator("eq")
+            .withParameter(Integer.toString(value))
+            .withParameter(fieldOrEvaluator);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param value
+     * @param fieldOrEvaluator
+     * @return
+     */
+    public static BooleanEvaluator eq(double value, FieldOrEvaluator fieldOrEvaluator) {
+        return (BooleanEvaluator) new BooleanEvaluator("eq")
+            .withParameter(Double.toString(value))
+            .withParameter(fieldOrEvaluator);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#eq">Stream Evaluator Reference: eq</a>
+     * @param value
+     * @param fieldOrEvaluator
+     * @return
+     */
+    public static BooleanEvaluator eq(float value, FieldOrEvaluator fieldOrEvaluator) {
+        return (BooleanEvaluator) new BooleanEvaluator("eq")
+            .withParameter(Float.toString(value))
+            .withParameter(fieldOrEvaluator);
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Evaluator.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Evaluator.java
@@ -1,13 +1,16 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
+import com.github.thesench.solr.dsl.stream.expr.params.Alias;
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
+
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
-public class Evaluator extends StreamExpression {
+public class Evaluator extends StreamExpression implements FieldOrEvaluator {
     public Evaluator(String functionName) {
         super(functionName);
     }
 
-    public String as(String alias) {
-        return null;
+    public Alias as(String alias) {
+        return new Alias(this.toString(), alias);
     }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Evaluator.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Evaluator.java
@@ -3,7 +3,11 @@ package com.github.thesench.solr.dsl.stream.expr.evaluators;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
 public class Evaluator extends StreamExpression {
-    public Evaluator(String value) {
-        super(value);
+    public Evaluator(String functionName) {
+        super(functionName);
+    }
+
+    public String as(String alias) {
+        return null;
     }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/If.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/If.java
@@ -1,0 +1,231 @@
+package com.github.thesench.solr.dsl.stream.expr.evaluators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
+
+public class If {
+    private If() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, FieldOrEvaluator whenTrue, FieldOrEvaluator whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(whenTrue)
+            .withParameter(whenFalse);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, int whenTrue, FieldOrEvaluator whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Integer.toString(whenTrue))
+            .withParameter(whenFalse);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, float whenTrue, FieldOrEvaluator whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Float.toString(whenTrue))
+            .withParameter(whenFalse);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, double whenTrue, FieldOrEvaluator whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Double.toString(whenTrue))
+            .withParameter(whenFalse);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, FieldOrEvaluator whenTrue, int whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(whenTrue)
+            .withParameter(Integer.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, int whenTrue, int whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Integer.toString(whenTrue))
+            .withParameter(Integer.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, float whenTrue, int whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Float.toString(whenTrue))
+            .withParameter(Integer.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, double whenTrue, int whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Double.toString(whenTrue))
+            .withParameter(Integer.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, FieldOrEvaluator whenTrue, float whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(whenTrue)
+            .withParameter(Float.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, int whenTrue, float whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Integer.toString(whenTrue))
+            .withParameter(Float.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, float whenTrue, float whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Float.toString(whenTrue))
+            .withParameter(Float.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, double whenTrue, float whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Double.toString(whenTrue))
+            .withParameter(Float.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, FieldOrEvaluator whenTrue, double whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(whenTrue)
+            .withParameter(Double.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, int whenTrue, double whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Integer.toString(whenTrue))
+            .withParameter(Double.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, float whenTrue, double whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Float.toString(whenTrue))
+            .withParameter(Double.toString(whenFalse));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#if">Stream Evaluator Reference: if</a>
+     * @param condition
+     * @param whenTrue
+     * @param whenFalse
+     * @return
+     */
+    public static Evaluator if_(BooleanEvaluator condition, double whenTrue, double whenFalse) {
+        return (Evaluator) new Evaluator("if")
+            .withParameter(condition)
+            .withParameter(Double.toString(whenTrue))
+            .withParameter(Double.toString(whenFalse));
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/NumberEvaluator.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/NumberEvaluator.java
@@ -1,7 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
 public class NumberEvaluator extends Evaluator {
-    public NumberEvaluator(String value) {
-        super(value);
+    public NumberEvaluator(String functionName) {
+        super(functionName);
     }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
@@ -1,10 +1,8 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
-import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
 import com.sun.jdi.Field;
 
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.solr.client.solrj.io.stream.expr.Expressible;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
 public class StreamEvaluators {

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
@@ -1,8 +1,10 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrEvaluator;
 import com.sun.jdi.Field;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.solr.client.solrj.io.stream.expr.Expressible;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
 public class StreamEvaluators {
@@ -62,10 +64,6 @@ public class StreamEvaluators {
      */
     public static NumberEvaluator abs(float rawNumber) {
         return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Float.toString(rawNumber));
-    }
-
-    public static StreamExpression add() {
-        throw new NotImplementedException();
     }
 
     public static StreamExpression analyze() {
@@ -212,10 +210,6 @@ public class StreamEvaluators {
         throw new NotImplementedException();
     }
 
-    public static StreamExpression eq() {
-        throw new NotImplementedException();
-    }
-
     public static StreamExpression expMovingAge() {
         throw new NotImplementedException();
     }
@@ -283,10 +277,6 @@ public class StreamEvaluators {
     public static StreamExpression hsin() {
         throw new NotImplementedException();
     }
-
-    // public static StreamExpression if() {
-    //     throw new NotImplementedException();
-    // }
 
     public static StreamExpression indexOf() {
         throw new NotImplementedException();

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
@@ -1,5 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
+import com.sun.jdi.Field;
+
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
@@ -13,9 +15,17 @@ public class StreamEvaluators {
      * @param fieldName
      * @return
      */
-    public static Evaluator abs(String fieldName) {
-        StreamExpression expression = new Evaluator("abs").withParameter(fieldName);
-        return (Evaluator) expression;
+    public static NumberEvaluator abs(String fieldName) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(fieldName);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param field
+     * @return
+     */
+    public static NumberEvaluator abs(Field field) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(field.toString());
     }
 
     /**
@@ -23,9 +33,8 @@ public class StreamEvaluators {
      * @param rawNumber
      * @return
      */
-    public static Evaluator abs(int rawNumber) {
-        StreamExpression expression = new Evaluator("abs").withParameter(Integer.toString(rawNumber));
-        return (Evaluator) expression;
+    public static NumberEvaluator abs(int rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Integer.toString(rawNumber));
     }
 
     /**
@@ -33,9 +42,8 @@ public class StreamEvaluators {
      * @param rawNumber
      * @return
      */
-    public static Evaluator abs(short rawNumber) {
-        StreamExpression expression = new Evaluator("abs").withParameter(Short.toString(rawNumber));
-        return (Evaluator) expression;
+    public static NumberEvaluator abs(long rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Long.toString(rawNumber));
     }
 
     /**
@@ -43,9 +51,8 @@ public class StreamEvaluators {
      * @param rawNumber
      * @return
      */
-    public static Evaluator abs(long rawNumber) {
-        StreamExpression expression = new Evaluator("abs").withParameter(Long.toString(rawNumber));
-        return (Evaluator) expression;
+    public static NumberEvaluator abs(double rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Double.toString(rawNumber));
     }
 
     /**
@@ -53,19 +60,8 @@ public class StreamEvaluators {
      * @param rawNumber
      * @return
      */
-    public static Evaluator abs(double rawNumber) {
-        StreamExpression expression = new Evaluator("abs").withParameter(Double.toString(rawNumber));
-        return (Evaluator) expression;
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param rawNumber
-     * @return
-     */
-    public static Evaluator abs(float rawNumber) {
-        StreamExpression expression = new Evaluator("abs").withParameter(Float.toString(rawNumber));
-        return (Evaluator) expression;
+    public static NumberEvaluator abs(float rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Float.toString(rawNumber));
     }
 
     public static StreamExpression add() {

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Alias.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Alias.java
@@ -1,18 +1,29 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import java.util.function.BiFunction;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 
-public class Alias implements FieldOrAlias {
-    private final String fieldName;
+public class Alias extends StreamExpressionValue implements FieldOrAlias {
     private final String alias;
 
     public Alias(String fieldName, String alias) {
-        this.fieldName = fieldName;
+        super(fieldName);
         this.alias = alias;
     }
 
     @Override
-    public String format(BiFunction<String, String, String> aliasFormatter) {
-        return aliasFormatter.apply(fieldName, alias);
+    public StreamExpressionParameter format(AliasType aliasType) {
+        String value;
+        switch(aliasType) {
+            case AS:
+                value = String.join(" as ", getValue(), alias);
+                break;
+            case COLON:
+                value = String.join(":", alias, getValue());
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid AliasType specified");
+        }
+        return new StreamExpressionValue(value);
     }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Alias.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Alias.java
@@ -1,0 +1,18 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import java.util.function.BiFunction;
+
+public class Alias implements FieldOrAlias {
+    private final String fieldName;
+    private final String alias;
+
+    public Alias(String fieldName, String alias) {
+        this.fieldName = fieldName;
+        this.alias = alias;
+    }
+
+    @Override
+    public String format(BiFunction<String, String, String> aliasFormatter) {
+        return aliasFormatter.apply(fieldName, alias);
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Alias.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Alias.java
@@ -3,7 +3,7 @@ package com.github.thesench.solr.dsl.stream.expr.params;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 
-public class Alias extends StreamExpressionValue implements FieldOrAlias {
+public class Alias extends StreamExpressionValue implements FieldOrAlias, FieldOrAliasOrReplace {
     private final String alias;
 
     public Alias(String fieldName, String alias) {

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/AliasType.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/AliasType.java
@@ -1,0 +1,6 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+public enum AliasType {
+    AS,
+    COLON;
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Field.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Field.java
@@ -1,25 +1,18 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import java.util.function.BiFunction;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 
-public class Field implements FieldOrAlias {
-    private final String fieldName;
+public class Field extends StreamExpressionValue implements FieldOrAlias {
 
     public Field(String fieldName) {
-        this.fieldName = fieldName;
-    }
-
-    @Override
-    public String format(BiFunction<String, String, String> aliasFormatter) {
-        return fieldName;
-    }
-
-    @Override
-    public String toString() {
-        return fieldName;
+        super(fieldName);
     }
 
     public Alias as(String alias) {
-        return new Alias(this.fieldName, alias);
+        return new Alias(this.getValue(), alias);
+    }
+
+    public StreamExpressionValue format(AliasType aliasType) {
+        return this;
     }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Field.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Field.java
@@ -1,0 +1,25 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import java.util.function.BiFunction;
+
+public class Field implements FieldOrAlias {
+    private final String fieldName;
+
+    public Field(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public String format(BiFunction<String, String, String> aliasFormatter) {
+        return fieldName;
+    }
+
+    @Override
+    public String toString() {
+        return fieldName;
+    }
+
+    public Alias as(String alias) {
+        return new Alias(this.fieldName, alias);
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Field.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Field.java
@@ -2,7 +2,7 @@ package com.github.thesench.solr.dsl.stream.expr.params;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 
-public class Field extends StreamExpressionValue implements FieldOrAlias {
+public class Field extends StreamExpressionValue implements FieldOrAlias, FieldOrAliasOrReplace, FieldOrEvaluator {
 
     public Field(String fieldName) {
         super(fieldName);

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrAlias.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrAlias.java
@@ -1,7 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import java.util.function.BiFunction;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 
-public interface FieldOrAlias {
-    public String format(BiFunction<String, String, String> aliasFormatter);
+public interface FieldOrAlias extends StreamExpressionParameter {
+    public StreamExpressionParameter format(AliasType aliasType);
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrAlias.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrAlias.java
@@ -1,0 +1,7 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import java.util.function.BiFunction;
+
+public interface FieldOrAlias {
+    public String format(BiFunction<String, String, String> aliasFormatter);
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrAliasOrReplace.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrAliasOrReplace.java
@@ -1,0 +1,7 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
+
+public interface FieldOrAliasOrReplace {
+    public StreamExpressionParameter format(AliasType aliasType);
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrEvaluator.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FieldOrEvaluator.java
@@ -1,0 +1,7 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
+
+public interface FieldOrEvaluator extends StreamExpressionParameter {
+    
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/On.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/On.java
@@ -16,4 +16,20 @@ public class On extends StreamExpressionNamedParameter {
     private void setParameter(String fieldInLeft, String fieldInRight) {
         super.setParameter(fieldInLeft + "=" + fieldInRight);
     }
+
+    public static On on(String fieldInBoth) {
+        return new On(fieldInBoth);
+    }
+
+    public static On on(String fieldInLeft, String fieldInRight) {
+        return new On(fieldInLeft, fieldInRight);
+    }
+
+    public static On on(Field fieldInBoth) {
+        return new On(fieldInBoth.getValue());
+    }
+
+    public static On on(Field fieldInLeft, Field fieldInRight) {
+        return new On(fieldInLeft.getValue(), fieldInRight.getValue());
+    }
 }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/RawValue.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/RawValue.java
@@ -1,0 +1,25 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
+
+public class RawValue extends StreamExpressionValue {
+    public RawValue(String value) {
+        super(value);
+    }
+
+    public static RawValue raw(String value) {
+        return new RawValue(value);
+    }
+
+    public static RawValue raw(int value) {
+        return new RawValue(Integer.toString(value));
+    }
+
+    public static RawValue raw(double value) {
+        return new RawValue(Double.toString(value));
+    }
+
+    public static RawValue raw(float value) {
+        return new RawValue(Float.toString(value));
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Replace.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Replace.java
@@ -1,0 +1,86 @@
+package com.github.thesench.solr.dsl.stream.expr.params;
+
+import com.github.thesench.solr.dsl.stream.expr.params.Replace.WithValue;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
+
+
+interface EmptyReplace {
+    ReplaceWithField withFieldName(String fieldName);
+    ReplaceWithField withField(Field field);
+};
+
+interface ReplaceWithField {
+    ReplaceMissingReplacement withValue(String value);
+}
+
+interface ReplaceMissingReplacement {
+    Replace withReplacement(WithValue withValue);
+}
+
+public class Replace extends StreamExpression implements FieldAliasOrReplace {
+
+    public Replace() {
+        super("replace");
+    }
+
+    @Override
+    public StreamExpressionParameter format(AliasType aliasType) {
+        return this;
+    }
+
+    public static Replace replace(Field field, String value, WithValue replacement) {
+        return new ReplaceBuilder()
+            .withField(field)
+            .withValue(value)
+            .withReplacement(replacement);
+    }
+
+    public static class ReplaceBuilder implements EmptyReplace, ReplaceWithField, ReplaceMissingReplacement {
+        public Replace replace;
+
+        @Override
+        public ReplaceWithField withFieldName(String fieldName) {
+            replace.addParameter(fieldName);
+            return this;
+        }
+    
+        @Override
+        public ReplaceWithField withField(Field field) {
+            String fieldName = field.toString();
+            return this.withFieldName(fieldName);
+        }
+    
+        @Override
+        public ReplaceMissingReplacement withValue(String value) {
+            replace.addParameter(value);
+            return this;
+        }
+
+        @Override
+        public Replace withReplacement(WithValue withValue) {
+            replace.addParameter(withValue);
+            return replace;
+        }
+    }
+
+    public static class WithValue extends StreamExpressionNamedParameter {
+        public WithValue(String value) {
+            super("withValue", value);
+        }
+
+        public static WithValue withValue(String value) {
+            return new WithValue(value);
+        }
+
+        public static WithValue withValue(int value) {
+            return new WithValue(Integer.toString(value));
+        }
+
+        public static WithValue withValue(double value) {
+            return new WithValue(Double.toString(value));
+        }
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Replace.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Replace.java
@@ -20,7 +20,7 @@ interface ReplaceMissingReplacement {
     Replace withReplacement(WithValue withValue);
 }
 
-public class Replace extends StreamExpression implements FieldAliasOrReplace {
+public class Replace extends StreamExpression implements FieldOrAliasOrReplace {
 
     public Replace() {
         super("replace");
@@ -39,7 +39,7 @@ public class Replace extends StreamExpression implements FieldAliasOrReplace {
     }
 
     public static class ReplaceBuilder implements EmptyReplace, ReplaceWithField, ReplaceMissingReplacement {
-        public Replace replace;
+        public Replace replace = new Replace();
 
         @Override
         public ReplaceWithField withFieldName(String fieldName) {

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/SortFields.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/SortFields.java
@@ -16,8 +16,20 @@ public class SortFields {
         return new SortFields(sortField);
     }
 
+    public static SortFields by(Field field, SortDirection sortDirection) {
+        SortField sortField = new SortField(field.getValue(), sortDirection);
+        return new SortFields(sortField);
+    }
+
     public SortFields thenBy(String field, SortDirection sortDirection) {
         SortField sortField = new SortField(field, sortDirection);
+        lastSortField.nextSortField = sortField;
+        lastSortField = sortField;
+        return this;
+    }
+
+    public SortFields thenBy(Field field, SortDirection sortDirection) {
+        SortField sortField = new SortField(field.getValue(), sortDirection);
         lastSortField.nextSortField = sortField;
         lastSortField = sortField;
         return this;

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/StreamParameters.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/StreamParameters.java
@@ -41,14 +41,6 @@ public class StreamParameters {
         return new N(n);
     }
 
-    public static On on(String fieldInBoth) {
-        return new On(fieldInBoth);
-    }
-
-    public static On on(String fieldInLeft, String fieldInRight) {
-        return new On(fieldInLeft, fieldInRight);
-    }
-
     public static ProductSort productSort(SortFields sortFields) {
         return new ProductSort(sortFields.toString());
     }

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
@@ -9,6 +9,8 @@ import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.p
 import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.thesench.solr.dsl.stream.expr.params.Field;
+
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,7 @@ public class CartesianProductTest {
         
         assertEquals(expected, expression.toString());
     }
+
     @Test
     void cartesianProduct_givenStreamFieldNameAndSort_returnsCartesianProductStream() {
         String expected =
@@ -42,6 +45,44 @@ public class CartesianProductTest {
             cartesianProduct(
                 search("testCollection"),
                 "someField",
+                productSort(by("someField", ASC).thenBy("someOtherField", DESC))
+            );
+        
+        assertEquals(expected, expression.toString());
+    }
+
+    @Test
+    void cartesianProduct_givenStreamAndField_returnsCartesianProductStream() {
+        Field someField = new Field("someField");
+        String expected =
+           "cartesianProduct(" +
+                "search(testCollection)," +
+                "someField" +
+            ")";
+
+        StreamExpression expression =
+            cartesianProduct(
+                search("testCollection"),
+                someField
+            );
+        
+        assertEquals(expected, expression.toString());
+    }
+
+    @Test
+    void cartesianProduct_givenStreamFieldAndSort_returnsCartesianProductStream() {
+        Field someField = new Field("someField");
+        String expected =
+            "cartesianProduct(" +
+                "search(testCollection)," +
+                "someField," +
+                "productSort=\"someField asc,someOtherField desc\"" +
+            ")";
+
+        StreamExpression expression =
+            cartesianProduct(
+                search("testCollection"),
+                someField,
                 productSort(by("someField", ASC).thenBy("someOtherField", DESC))
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ComplementTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ComplementTest.java
@@ -3,7 +3,7 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.complement;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/FetchTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/FetchTest.java
@@ -3,7 +3,7 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.fetch;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoinTest.java
@@ -4,7 +4,7 @@ import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorato
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.hashed;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoinTest.java
@@ -3,7 +3,7 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.innerJoin;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/IntersectTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/IntersectTest.java
@@ -3,7 +3,7 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.intersect;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoinTest.java
@@ -3,7 +3,7 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.leftOuterJoin;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ListTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ListTest.java
@@ -1,7 +1,6 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.list;
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.sort;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoinTest.java
@@ -4,7 +4,7 @@ import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorato
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.hashed;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SelectTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SelectTest.java
@@ -1,6 +1,12 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.select;
+import static com.github.thesench.solr.dsl.stream.expr.evaluators.Add.add;
+import static com.github.thesench.solr.dsl.stream.expr.evaluators.Div.div;
+import static com.github.thesench.solr.dsl.stream.expr.evaluators.Eq.eq;
+import static com.github.thesench.solr.dsl.stream.expr.evaluators.If.if_;
+import static com.github.thesench.solr.dsl.stream.expr.params.Replace.replace;
+import static com.github.thesench.solr.dsl.stream.expr.params.Replace.WithValue.withValue;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
@@ -9,13 +15,15 @@ import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.s
 import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.thesench.solr.dsl.stream.expr.params.Field;
+
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
 
 public class SelectTest {
     
     @Test
-    void selectTest() {
+    void select_whenGivenStrings_returnsSelectStream() {
         String expected =
             "select(" +
                 "search(collection1,fl=\"id,teamName_s,wins,losses\",q=\"*:*\",qt=\"/export\",sort=\"id asc\")," +
@@ -36,6 +44,40 @@ public class SelectTest {
                 "replace(wins,null,withValue=0)",
                 "replace(losses,null,withValue=0)",
                 "if(eq(0,wins),0,div(add(wins,losses),wins)) as winPercentage"
+            );
+
+        assertEquals(expected, expression.toString());
+    }
+    
+    @Test
+    void select_whenGivenFieldsOrAliases_returnsSelectStream() {
+        Field teamName_s = new Field("teamName_s");
+        Field wins = new Field("wins");
+        Field losses = new Field("losses");
+        String expected =
+            "select(" +
+                "search(collection1,fl=\"id,teamName_s,wins,losses\",q=\"*:*\",qt=\"/export\",sort=\"id asc\")," +
+                "teamName_s as teamName," +
+                "wins," +
+                "losses," +
+                "replace(wins,null,withValue=0)," +
+                "replace(losses,null,withValue=0)," +
+                "if(eq(0,wins),0,div(add(wins,losses),wins)) as winPercentage" +
+            ")";
+        
+        StreamExpression expression =
+            select(
+                search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
+                teamName_s.as("teamName"),
+                wins,
+                losses,
+                replace(wins, null, withValue(0)),
+                replace(losses, null, withValue(0)),
+                if_(
+                    eq(0, wins),
+                    0,
+                    div(add(wins, losses), wins)
+                ).as("winPercentage")
             );
 
         assertEquals(expected, expression.toString());

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
@@ -5,7 +5,7 @@ import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorato
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.by;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.fl;
-import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.on;
+import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.StreamParameters.sort;


### PR DESCRIPTION
Add the concept of a `Field` class, along with `Alias`.  This allows for stricter type-checking and easier handling of aliases.

The overall idea is that instances of `Field` would be declared as "constants" that could then be referenced while building queries.  The various decorators/evaluators currently accept any `String` as a parameter, but adding these concepts would allow the API to be further constrained so that it's clearer what values they take in.  As an added bonus, using a class to represent aliases allows the system to handle formatting of aliases for the developer (e.g. `alias:field` vs `field as alias`).