### PR TITLE
Feature/move static methods to dedicated classes

### DIFF
--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProduct.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProduct.java
@@ -1,0 +1,90 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.evaluators.Evaluator;
+import com.github.thesench.solr.dsl.stream.expr.params.Field;
+import com.github.thesench.solr.dsl.stream.expr.params.ProductSort;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class CartesianProduct {
+    private CartesianProduct() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param fieldName
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, String fieldName) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(fieldName);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param fieldName
+     * @param productSort
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, String fieldName, ProductSort productSort) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(fieldName)
+            .withParameter(productSort);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param field
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Field field) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(field.toString());
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param field
+     * @param productSort
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Field field, ProductSort productSort) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(field.toString())
+            .withParameter(productSort);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param evaluator
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Evaluator evaluator) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(evaluator);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
+     * @param incomingStream
+     * @param evaluator
+     * @param productSort
+     * @return
+     */
+    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Evaluator evaluator, ProductSort productSort) {
+        return new StreamExpression("cartesianProduct")
+            .withParameter(incomingStream)
+            .withParameter(evaluator)
+            .withParameter(productSort);
+    }
+    
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Complement.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Complement.java
@@ -1,0 +1,24 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Complement {
+    private Complement() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#complement">Stream Decorator Reference: complement</a>
+     * @param leftStream
+     * @param rightStream
+     * @param onClause
+     * @return
+     */
+    public static StreamExpression complement(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
+        return new StreamExpression("complement")
+            .withParameter(leftStream)
+            .withParameter(rightStream)
+            .withParameter(onClause);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Fetch.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Fetch.java
@@ -1,0 +1,46 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.BatchSize;
+import com.github.thesench.solr.dsl.stream.expr.params.FL;
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Fetch {
+    private Fetch() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#fetch">Stream Decorator Reference: fetch</a>
+     * @param collection
+     * @param stream
+     * @param fl
+     * @param on
+     * @return
+     */
+    public static StreamExpression fetch(String collection, StreamExpression stream, FL fl, On on) {
+        return new StreamExpression("fetch")
+            .withParameter(collection)
+            .withParameter(stream)
+            .withParameter(fl)
+            .withParameter(on);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#fetch">Stream Decorator Reference: fetch</a>
+     * @param collection
+     * @param stream
+     * @param fl
+     * @param on
+     * @param batchSize
+     * @return
+     */
+    public static StreamExpression fetch(String collection, StreamExpression stream, FL fl, On on, BatchSize batchSize) {
+        return new StreamExpression("fetch")
+            .withParameter(collection)
+            .withParameter(stream)
+            .withParameter(fl)
+            .withParameter(on)
+            .withParameter(batchSize);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoin.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoin.java
@@ -1,0 +1,25 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class HashJoin {
+    private HashJoin() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#hashJoin">Stream Decorator Reference: hashJoin</a>
+     * @param leftStream
+     * @param rightStream
+     * @param onClause
+     * @return
+     */
+    public static StreamExpression hashJoin(StreamExpression leftStream, Hashed rightStream, On onClause) {
+        return new StreamExpression("hashJoin")
+            .withParameter(leftStream)
+            .withParameter(rightStream)
+            .withParameter(onClause);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoin.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoin.java
@@ -1,0 +1,24 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class InnerJoin {
+    private InnerJoin() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#innerJoin">Stream Decorator Reference: innerJoin</a>
+     * @param leftStream
+     * @param rightStream
+     * @param onClause
+     * @return
+     */
+    public static StreamExpression innerJoin(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
+        return new StreamExpression("innerJoin")
+            .withParameter(leftStream)
+            .withParameter(rightStream)
+            .withParameter(onClause);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Intersect.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Intersect.java
@@ -1,0 +1,24 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Intersect {
+    private Intersect() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#intersect">Stream Decorator Reference: intersect</a>
+     * @param leftStream
+     * @param rightStream
+     * @param onClause
+     * @return
+     */
+    public static StreamExpression intersect(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
+        return new StreamExpression("intersect")
+            .withParameter(leftStream)
+            .withParameter(rightStream)
+            .withParameter(onClause);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoin.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoin.java
@@ -1,0 +1,24 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class LeftOuterJoin {
+    private LeftOuterJoin() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#leftOuterJoin">Stream Decorator Reference: leftOuterJoin</a>
+     * @param leftStream
+     * @param rightStream
+     * @param onClause
+     * @return
+     */
+    public static StreamExpression leftOuterJoin(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
+        return new StreamExpression("leftOuterJoin")
+            .withParameter(leftStream)
+            .withParameter(rightStream)
+            .withParameter(onClause);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/List.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/List.java
@@ -1,0 +1,33 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class List {
+    private List() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#list">Stream Decorator Reference: list</a>
+     * @param stream1
+     * @param stream2
+     * @return
+     */
+    public static StreamExpression list(StreamExpression stream1, StreamExpression stream2) {
+        return new StreamExpression("list")
+            .withParameter(stream1)
+            .withParameter(stream2);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#list">Stream Decorator Reference: list</a>
+     * @param streams
+     * @return
+     */
+    public static StreamExpression list(StreamExpression... streams) {
+        StreamExpression expression = new StreamExpression("list");
+        for (StreamExpression stream : streams) {
+            expression.addParameter(stream);
+        }
+        return expression;
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoin.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoin.java
@@ -1,0 +1,25 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
+import com.github.thesench.solr.dsl.stream.expr.params.On;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class OuterHashJoin {
+    private OuterHashJoin() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#outerHashJoin">Stream Decorator Reference: outerHashJoin</a>
+     * @param leftStream
+     * @param rightStream
+     * @param onClause
+     * @return
+     */
+    public static StreamExpression outerHashJoin(StreamExpression leftStream, Hashed rightStream, On onClause) {
+        return new StreamExpression("outerHashJoin")
+            .withParameter(leftStream)
+            .withParameter(rightStream)
+            .withParameter(onClause);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Select.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Select.java
@@ -1,0 +1,43 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
+import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
+
+public class Select {
+    private Select() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#select">Stream Decorator Reference: select</a>
+     * @param stream
+     * @param fields
+     * @return
+     */
+    public static StreamExpression select(StreamExpression stream, String ...fields) {
+        StreamExpression selectStream = new StreamExpression("select")
+            .withParameter(stream);
+        for (String field : fields) {
+            selectStream.addParameter(field);
+        }
+        return selectStream;
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#select">Stream Decorator Reference: select</a>
+     * @param stream
+     * @param fields
+     * @return
+     */
+    public static StreamExpression select(StreamExpression stream, FieldOrAliasOrReplace... fields) {
+        StreamExpression selectStream = new StreamExpression("select")
+            .withParameter(stream);
+        for (FieldOrAliasOrReplace fieldOrAlias : fields) {
+            StreamExpressionParameter formattedField = fieldOrAlias.format(AliasType.AS);
+            selectStream.addParameter(formattedField);
+        }
+        return selectStream;
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Sort.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Sort.java
@@ -1,0 +1,22 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.By;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Sort {
+    private Sort() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#sort">Stream Decorator Reference: sort</a>
+     * @param stream
+     * @param by
+     * @return
+     */
+    public static StreamExpression sort(StreamExpression stream, By by) {
+        return new StreamExpression("sort")
+            .withParameter(stream)
+            .withParameter(by);
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -1,15 +1,12 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
-import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
 import com.github.thesench.solr.dsl.stream.expr.params.Reducer;
 import com.github.thesench.solr.dsl.stream.expr.params.Sort;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
-import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 
 public class StreamDecorators {
     private StreamDecorators() {}
@@ -107,37 +104,6 @@ public class StreamDecorators {
 
     public static StreamExpression scoreNodes() {
         throw new NotImplementedException();
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#select">Stream Decorator Reference: select</a>
-     * @param stream
-     * @param fields
-     * @return
-     */
-    public static StreamExpression select(StreamExpression stream, String ...fields) {
-        StreamExpression selectStream = new StreamExpression("select")
-            .withParameter(stream);
-        for (String field : fields) {
-            selectStream.addParameter(field);
-        }
-        return selectStream;
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#select">Stream Decorator Reference: select</a>
-     * @param stream
-     * @param fields
-     * @return
-     */
-    public static StreamExpression select(StreamExpression stream, FieldOrAliasOrReplace... fields) {
-        StreamExpression selectStream = new StreamExpression("select")
-            .withParameter(stream);
-        for (FieldOrAliasOrReplace fieldOrAlias : fields) {
-            StreamExpressionParameter formattedField = fieldOrAlias.format(AliasType.AS);
-            selectStream.addParameter(formattedField);
-        }
-        return selectStream;
     }
 
     /**

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -107,18 +107,6 @@ public class StreamDecorators {
     }
 
     /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#sort">Stream Decorator Reference: sort</a>
-     * @param stream
-     * @param by
-     * @return
-     */
-    public static StreamExpression sort(StreamExpression stream, By by) {
-        return new StreamExpression("sort")
-            .withParameter(stream)
-            .withParameter(by);
-    }
-
-    /**
      * @see <ahref="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#top">Stream Decorator Reference: top</a>
      * @param n
      * @param stream

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -1,9 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
 import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
-import com.github.thesench.solr.dsl.stream.expr.params.BatchSize;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
-import com.github.thesench.solr.dsl.stream.expr.params.FL;
 import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
 import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
@@ -40,40 +38,6 @@ public class StreamDecorators {
 
     public static StreamExpression executor() {
         throw new NotImplementedException();
-    }
-    
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#fetch">Stream Decorator Reference: fetch</a>
-     * @param collection
-     * @param stream
-     * @param fl
-     * @param on
-     * @return
-     */
-    public static StreamExpression fetch(String collection, StreamExpression stream, FL fl, On on) {
-        return new StreamExpression("fetch")
-            .withParameter(collection)
-            .withParameter(stream)
-            .withParameter(fl)
-            .withParameter(on);
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#fetch">Stream Decorator Reference: fetch</a>
-     * @param collection
-     * @param stream
-     * @param fl
-     * @param on
-     * @param batchSize
-     * @return
-     */
-    public static StreamExpression fetch(String collection, StreamExpression stream, FL fl, On on, BatchSize batchSize) {
-        return new StreamExpression("fetch")
-            .withParameter(collection)
-            .withParameter(stream)
-            .withParameter(fl)
-            .withParameter(on)
-            .withParameter(batchSize);
     }
     
     /**

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -4,7 +4,6 @@ import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
 import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
-import com.github.thesench.solr.dsl.stream.expr.params.On;
 import com.github.thesench.solr.dsl.stream.expr.params.Reducer;
 import com.github.thesench.solr.dsl.stream.expr.params.Sort;
 
@@ -43,20 +42,6 @@ public class StreamDecorators {
         throw new NotImplementedException();
     }
 
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#intersect">Stream Decorator Reference: intersect</a>
-     * @param leftStream
-     * @param rightStream
-     * @param onClause
-     * @return
-     */
-    public static StreamExpression intersect(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
-        return new StreamExpression("intersect")
-            .withParameter(leftStream)
-            .withParameter(rightStream)
-            .withParameter(onClause);
-    }
-    
     /**
      * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#list">Stream Decorator Reference: list</a>
      * @param stream1

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -1,16 +1,13 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import com.github.thesench.solr.dsl.stream.expr.evaluators.Evaluator;
 import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
 import com.github.thesench.solr.dsl.stream.expr.params.BatchSize;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
 import com.github.thesench.solr.dsl.stream.expr.params.FL;
-import com.github.thesench.solr.dsl.stream.expr.params.Field;
 import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
 import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
 import com.github.thesench.solr.dsl.stream.expr.params.On;
-import com.github.thesench.solr.dsl.stream.expr.params.ProductSort;
 import com.github.thesench.solr.dsl.stream.expr.params.Reducer;
 import com.github.thesench.solr.dsl.stream.expr.params.Sort;
 
@@ -20,84 +17,6 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 
 public class StreamDecorators {
     private StreamDecorators() {}
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
-     * @param incomingStream
-     * @param fieldName
-     * @return
-     */
-    public static StreamExpression cartesianProduct(StreamExpression incomingStream, String fieldName) {
-        return new StreamExpression("cartesianProduct")
-            .withParameter(incomingStream)
-            .withParameter(fieldName);
-    }
-    
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
-     * @param incomingStream
-     * @param fieldName
-     * @param productSort
-     * @return
-     */
-    public static StreamExpression cartesianProduct(StreamExpression incomingStream, String fieldName, ProductSort productSort) {
-        return new StreamExpression("cartesianProduct")
-            .withParameter(incomingStream)
-            .withParameter(fieldName)
-            .withParameter(productSort);
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
-     * @param incomingStream
-     * @param field
-     * @return
-     */
-    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Field field) {
-        return new StreamExpression("cartesianProduct")
-            .withParameter(incomingStream)
-            .withParameter(field.toString());
-    }
-    
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
-     * @param incomingStream
-     * @param field
-     * @param productSort
-     * @return
-     */
-    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Field field, ProductSort productSort) {
-        return new StreamExpression("cartesianProduct")
-            .withParameter(incomingStream)
-            .withParameter(field.toString())
-            .withParameter(productSort);
-    }
-    
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
-     * @param incomingStream
-     * @param evaluator
-     * @return
-     */
-    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Evaluator evaluator) {
-        return new StreamExpression("cartesianProduct")
-            .withParameter(incomingStream)
-            .withParameter(evaluator);
-    }
-    
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#cartesianproduct">Stream Decorator Reference: cartesianProduct</a>
-     * @param incomingStream
-     * @param evaluator
-     * @param productSort
-     * @return
-     */
-    public static StreamExpression cartesianProduct(StreamExpression incomingStream, Evaluator evaluator, ProductSort productSort) {
-        return new StreamExpression("cartesianProduct")
-            .withParameter(incomingStream)
-            .withParameter(evaluator)
-            .withParameter(productSort);
-    }
 
     public static StreamExpression classify() {
         throw new NotImplementedException();

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -39,31 +39,6 @@ public class StreamDecorators {
         throw new NotImplementedException();
     }
 
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#list">Stream Decorator Reference: list</a>
-     * @param stream1
-     * @param stream2
-     * @return
-     */
-    public static StreamExpression list(StreamExpression stream1, StreamExpression stream2) {
-        return new StreamExpression("list")
-            .withParameter(stream1)
-            .withParameter(stream2);
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#list">Stream Decorator Reference: list</a>
-     * @param streams
-     * @return
-     */
-    public static StreamExpression list(StreamExpression... streams) {
-        StreamExpression expression = new StreamExpression("list");
-        for (StreamExpression stream : streams) {
-            expression.addParameter(stream);
-        }
-        return expression;
-    }
-
     public static StreamExpression merge() {
         throw new NotImplementedException();
     }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -3,7 +3,6 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import com.github.thesench.solr.dsl.stream.expr.params.AliasType;
 import com.github.thesench.solr.dsl.stream.expr.params.By;
 import com.github.thesench.solr.dsl.stream.expr.params.FieldOrAliasOrReplace;
-import com.github.thesench.solr.dsl.stream.expr.params.Hashed;
 import com.github.thesench.solr.dsl.stream.expr.params.N;
 import com.github.thesench.solr.dsl.stream.expr.params.On;
 import com.github.thesench.solr.dsl.stream.expr.params.Reducer;
@@ -40,20 +39,6 @@ public class StreamDecorators {
         throw new NotImplementedException();
     }
     
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#hashJoin">Stream Decorator Reference: hashJoin</a>
-     * @param leftStream
-     * @param rightStream
-     * @param onClause
-     * @return
-     */
-    public static StreamExpression hashJoin(StreamExpression leftStream, Hashed rightStream, On onClause) {
-        return new StreamExpression("hashJoin")
-            .withParameter(leftStream)
-            .withParameter(rightStream)
-            .withParameter(onClause);
-    }
-
     public static StreamExpression having() {
         throw new NotImplementedException();
     }
@@ -72,34 +57,6 @@ public class StreamDecorators {
             .withParameter(onClause);
     }
     
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#innerJoin">Stream Decorator Reference: innerJoin</a>
-     * @param leftStream
-     * @param rightStream
-     * @param onClause
-     * @return
-     */
-    public static StreamExpression innerJoin(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
-        return new StreamExpression("innerJoin")
-            .withParameter(leftStream)
-            .withParameter(rightStream)
-            .withParameter(onClause);
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#leftOuterJoin">Stream Decorator Reference: leftOuterJoin</a>
-     * @param leftStream
-     * @param rightStream
-     * @param onClause
-     * @return
-     */
-    public static StreamExpression leftOuterJoin(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
-        return new StreamExpression("leftOuterJoin")
-            .withParameter(leftStream)
-            .withParameter(rightStream)
-            .withParameter(onClause);
-    }
-
     /**
      * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#list">Stream Decorator Reference: list</a>
      * @param stream1
@@ -133,20 +90,6 @@ public class StreamDecorators {
         throw new NotImplementedException();
     }
     
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#outerHashJoin">Stream Decorator Reference: outerHashJoin</a>
-     * @param leftStream
-     * @param rightStream
-     * @param onClause
-     * @return
-     */
-    public static StreamExpression outerHashJoin(StreamExpression leftStream, Hashed rightStream, On onClause) {
-        return new StreamExpression("outerHashJoin")
-            .withParameter(leftStream)
-            .withParameter(rightStream)
-            .withParameter(onClause);
-    }
-
     public static StreamExpression parallel() {
         throw new NotImplementedException();
     }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/StreamDecorators.java
@@ -26,20 +26,6 @@ public class StreamDecorators {
         throw new NotImplementedException();
     }
 
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-decorator-reference.html#complement">Stream Decorator Reference: complement</a>
-     * @param leftStream
-     * @param rightStream
-     * @param onClause
-     * @return
-     */
-    public static StreamExpression complement(StreamExpression leftStream, StreamExpression rightStream, On onClause) {
-        return new StreamExpression("complement")
-            .withParameter(leftStream)
-            .withParameter(rightStream)
-            .withParameter(onClause);
-    }
-
     public static StreamExpression daemon() {
         throw new NotImplementedException();
     }

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Top.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/decorators/Top.java
@@ -1,0 +1,6 @@
+package com.github.thesench.solr.dsl.stream.expr.decorators;
+
+public class Top {
+    private Top() {}
+    
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Abs.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/Abs.java
@@ -1,0 +1,62 @@
+package com.github.thesench.solr.dsl.stream.expr.evaluators;
+
+import com.github.thesench.solr.dsl.stream.expr.params.Field;
+
+public class Abs {
+    private Abs() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param fieldName
+     * @return
+     */
+    public static NumberEvaluator abs(String fieldName) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(fieldName);
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param field
+     * @return
+     */
+    public static NumberEvaluator abs(Field field) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(field.toString());
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param rawNumber
+     * @return
+     */
+    public static NumberEvaluator abs(int rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Integer.toString(rawNumber));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param rawNumber
+     * @return
+     */
+    public static NumberEvaluator abs(long rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Long.toString(rawNumber));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param rawNumber
+     * @return
+     */
+    public static NumberEvaluator abs(double rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Double.toString(rawNumber));
+    }
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
+     * @param rawNumber
+     * @return
+     */
+    public static NumberEvaluator abs(float rawNumber) {
+        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Float.toString(rawNumber));
+    }
+
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/evaluators/StreamEvaluators.java
@@ -1,67 +1,11 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
-import com.sun.jdi.Field;
-
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
 public class StreamEvaluators {
     public static StreamExpression acos() {
         throw new NotImplementedException();
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param fieldName
-     * @return
-     */
-    public static NumberEvaluator abs(String fieldName) {
-        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(fieldName);
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param field
-     * @return
-     */
-    public static NumberEvaluator abs(Field field) {
-        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(field.toString());
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param rawNumber
-     * @return
-     */
-    public static NumberEvaluator abs(int rawNumber) {
-        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Integer.toString(rawNumber));
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param rawNumber
-     * @return
-     */
-    public static NumberEvaluator abs(long rawNumber) {
-        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Long.toString(rawNumber));
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param rawNumber
-     * @return
-     */
-    public static NumberEvaluator abs(double rawNumber) {
-        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Double.toString(rawNumber));
-    }
-
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-evaluator-reference.html#abs">Stream Evaluator Reference: abs</a>
-     * @param rawNumber
-     * @return
-     */
-    public static NumberEvaluator abs(float rawNumber) {
-        return (NumberEvaluator) new NumberEvaluator("abs").withParameter(Float.toString(rawNumber));
     }
 
     public static StreamExpression analyze() {
@@ -169,10 +113,6 @@ public class StreamEvaluators {
     }
 
     public static StreamExpression distance() {
-        throw new NotImplementedException();
-    }
-
-    public static StreamExpression div() {
         throw new NotImplementedException();
     }
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FL.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FL.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.common.params.CommonParams;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FQ.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/FQ.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.common.params.CommonParams;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Q.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Q.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.common.params.CommonParams;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/QT.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/QT.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.common.params.CommonParams;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/RawSearchParameter.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/RawSearchParameter.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 
 public class RawSearchParameter extends StreamExpressionNamedParameter implements SearchParameter {

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Rows.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Rows.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.common.params.CommonParams;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/SearchParameter.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/SearchParameter.java
@@ -1,4 +1,4 @@
-package com.github.thesench.solr.dsl.stream.expr.sources;
+package com.github.thesench.solr.dsl.stream.expr.params;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionParameter;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Sort.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/params/Sort.java
@@ -1,7 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.params;
 
-import com.github.thesench.solr.dsl.stream.expr.sources.SearchParameter;
-
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.common.params.CommonParams;
 

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/sources/Search.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/sources/Search.java
@@ -1,0 +1,21 @@
+package com.github.thesench.solr.dsl.stream.expr.sources;
+
+import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
+
+public class Search {
+    private Search() {}
+
+    /**
+     * @see <a href="https://solr.apache.org/guide/8_10/stream-source-reference.html#search">Stream Source Reference: search</a>
+     * @param collectionName
+     * @param params
+     * @return
+     */
+    public static StreamExpression search(String collectionName, SearchParameter ...params) {
+        StreamExpression searchExpression = new StreamExpression("search").withParameter(collectionName);
+        for (SearchParameter param : params) {
+            searchExpression.addParameter(param);
+        }
+        return searchExpression;
+    }
+}

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/sources/Search.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/sources/Search.java
@@ -1,5 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.sources;
 
+import com.github.thesench.solr.dsl.stream.expr.params.SearchParameter;
+
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 
 public class Search {

--- a/src/main/java/com/github/thesench/solr/dsl/stream/expr/sources/StreamSources.java
+++ b/src/main/java/com/github/thesench/solr/dsl/stream/expr/sources/StreamSources.java
@@ -46,20 +46,6 @@ public class StreamSources {
         throw new NotImplementedException();
     }
 
-    /**
-     * @see <a href="https://solr.apache.org/guide/8_10/stream-source-reference.html#search">Stream Source Reference: search</a>
-     * @param collectionName
-     * @param params
-     * @return
-     */
-    public static StreamExpression search(String collectionName, SearchParameter ...params) {
-        StreamExpression searchExpression = new StreamExpression("search").withParameter(collectionName);
-        for (SearchParameter param : params) {
-            searchExpression.addParameter(param);
-        }
-        return searchExpression;
-    }
-
     public static StreamExpression significantTerms() {
         throw new NotImplementedException();
     }

--- a/src/main/java/com/github/thesench/solr/example/Examples.java
+++ b/src/main/java/com/github/thesench/solr/example/Examples.java
@@ -1,7 +1,6 @@
 package com.github.thesench.solr.example;
 
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.reduce;
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.select;
 import static com.github.thesench.solr.dsl.stream.expr.params.By.by;
 import static com.github.thesench.solr.dsl.stream.expr.params.Reducer.group;
 import static com.github.thesench.solr.dsl.stream.expr.params.N.n;
@@ -13,6 +12,8 @@ import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.sea
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.github.thesench.solr.dsl.stream.expr.decorators.Select;
 
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.comp.ComparatorOrder;
@@ -181,7 +182,7 @@ public class Examples {
 
     public static void searchUsingDsl() throws IOException {
         StreamExpression streamExpression =
-            select(
+            Select.select(
                 reduce(
                     search(
                         "techproducts",

--- a/src/main/java/com/github/thesench/solr/example/Examples.java
+++ b/src/main/java/com/github/thesench/solr/example/Examples.java
@@ -7,13 +7,13 @@ import static com.github.thesench.solr.dsl.stream.expr.params.N.n;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.Rows.rows;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.github.thesench.solr.dsl.stream.expr.decorators.Select;
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.solr.client.solrj.io.comp.ComparatorOrder;
@@ -184,7 +184,7 @@ public class Examples {
         StreamExpression streamExpression =
             Select.select(
                 reduce(
-                    search(
+                    Search.search(
                         "techproducts",
                         q("popularity:[6 TO 10]"),
                         rows(25),

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
@@ -5,10 +5,10 @@ import static com.github.thesench.solr.dsl.stream.expr.params.SortDirection.ASC;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortDirection.DESC;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortFields.by;
 import static com.github.thesench.solr.dsl.stream.expr.params.ProductSort.productSort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.thesench.solr.dsl.stream.expr.params.Field;
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ public class CartesianProductTest {
 
         StreamExpression expression =
             CartesianProduct.cartesianProduct(
-                search("testCollection"),
+                Search.search("testCollection"),
                 "someField"
             );
         
@@ -42,7 +42,7 @@ public class CartesianProductTest {
 
         StreamExpression expression =
             CartesianProduct.cartesianProduct(
-                search("testCollection"),
+                Search.search("testCollection"),
                 "someField",
                 productSort(by("someField", ASC).thenBy("someOtherField", DESC))
             );
@@ -61,7 +61,7 @@ public class CartesianProductTest {
 
         StreamExpression expression =
             CartesianProduct.cartesianProduct(
-                search("testCollection"),
+                Search.search("testCollection"),
                 someField
             );
         
@@ -80,7 +80,7 @@ public class CartesianProductTest {
 
         StreamExpression expression =
             CartesianProduct.cartesianProduct(
-                search("testCollection"),
+                Search.search("testCollection"),
                 someField,
                 productSort(by("someField", ASC).thenBy("someOtherField", DESC))
             );
@@ -98,7 +98,7 @@ public class CartesianProductTest {
 
         StreamExpression expression = 
             CartesianProduct.cartesianProduct(
-                search("testCollection"),
+                Search.search("testCollection"),
                 abs(12)
             );
 
@@ -116,7 +116,7 @@ public class CartesianProductTest {
         
         StreamExpression expression =
             CartesianProduct.cartesianProduct(
-                search("testCollection"),
+                Search.search("testCollection"),
                 abs(12),
                 productSort("someField ASC")
             );

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.cartesianProduct;
 import static com.github.thesench.solr.dsl.stream.expr.evaluators.Abs.abs;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortDirection.ASC;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortDirection.DESC;
@@ -24,7 +23,7 @@ public class CartesianProductTest {
             ")";
 
         StreamExpression expression =
-            cartesianProduct(
+            CartesianProduct.cartesianProduct(
                 search("testCollection"),
                 "someField"
             );
@@ -42,7 +41,7 @@ public class CartesianProductTest {
             ")";
 
         StreamExpression expression =
-            cartesianProduct(
+            CartesianProduct.cartesianProduct(
                 search("testCollection"),
                 "someField",
                 productSort(by("someField", ASC).thenBy("someOtherField", DESC))
@@ -61,7 +60,7 @@ public class CartesianProductTest {
             ")";
 
         StreamExpression expression =
-            cartesianProduct(
+            CartesianProduct.cartesianProduct(
                 search("testCollection"),
                 someField
             );
@@ -80,7 +79,7 @@ public class CartesianProductTest {
             ")";
 
         StreamExpression expression =
-            cartesianProduct(
+            CartesianProduct.cartesianProduct(
                 search("testCollection"),
                 someField,
                 productSort(by("someField", ASC).thenBy("someOtherField", DESC))
@@ -98,7 +97,7 @@ public class CartesianProductTest {
             ")";
 
         StreamExpression expression = 
-            cartesianProduct(
+            CartesianProduct.cartesianProduct(
                 search("testCollection"),
                 abs(12)
             );
@@ -116,7 +115,7 @@ public class CartesianProductTest {
         ")";
         
         StreamExpression expression =
-            cartesianProduct(
+            CartesianProduct.cartesianProduct(
                 search("testCollection"),
                 abs(12),
                 productSort("someField ASC")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/CartesianProductTest.java
@@ -1,7 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.cartesianProduct;
-import static com.github.thesench.solr.dsl.stream.expr.evaluators.StreamEvaluators.abs;
+import static com.github.thesench.solr.dsl.stream.expr.evaluators.Abs.abs;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortDirection.ASC;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortDirection.DESC;
 import static com.github.thesench.solr.dsl.stream.expr.params.SortFields.by;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ComplementTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ComplementTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.complement;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
@@ -24,7 +23,7 @@ class ComplementTest {
             ")";
 
         StreamExpression expression =
-            complement(
+            Complement.complement(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
@@ -43,7 +42,7 @@ class ComplementTest {
             ")";
 
         StreamExpression expression =
-            complement(
+            Complement.complement(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ComplementTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ComplementTest.java
@@ -6,8 +6,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,8 @@ class ComplementTest {
 
         StreamExpression expression =
             Complement.complement(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
             );
         
@@ -43,8 +44,8 @@ class ComplementTest {
 
         StreamExpression expression =
             Complement.complement(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/FetchTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/FetchTest.java
@@ -6,8 +6,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ public class FetchTest {
         StreamExpression expression =
             Fetch.fetch(
                 "addresses",
-                search("people", q("*:*"), qt(EXPORT), fl("username", "firstName", "lastName"), sort("username asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("username", "firstName", "lastName"), sort("username asc")),
                 fl("streetAddress", "city", "state", "country", "zip"),
                 on("username","userId")
             );

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/FetchTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/FetchTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.fetch;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
@@ -25,7 +24,7 @@ public class FetchTest {
             ")";
 
         StreamExpression expression =
-            fetch(
+            Fetch.fetch(
                 "addresses",
                 search("people", q("*:*"), qt(EXPORT), fl("username", "firstName", "lastName"), sort("username asc")),
                 fl("streetAddress", "city", "state", "country", "zip"),

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoinTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.hashJoin;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.Hashed.hashed;
@@ -25,7 +24,7 @@ class HashJoinTest {
             ")";
 
         StreamExpression expression =
-            hashJoin(
+            HashJoin.hashJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 hashed(search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc"))),
                 on("personId")
@@ -44,7 +43,7 @@ class HashJoinTest {
             ")";
 
         StreamExpression expression =
-            hashJoin(
+            HashJoin.hashJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 hashed(search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc"))),
                 on("personId", "ownerId")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/HashJoinTest.java
@@ -7,8 +7,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,8 @@ class HashJoinTest {
 
         StreamExpression expression =
             HashJoin.hashJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                hashed(search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc"))),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                hashed(Search.search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc"))),
                 on("personId")
             );
         
@@ -44,8 +45,8 @@ class HashJoinTest {
 
         StreamExpression expression =
             HashJoin.hashJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                hashed(search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc"))),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                hashed(Search.search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc"))),
                 on("personId", "ownerId")
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoinTest.java
@@ -6,8 +6,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,8 @@ class InnerJoinTest {
 
         StreamExpression expression =
             InnerJoin.innerJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
             );
         
@@ -43,8 +44,8 @@ class InnerJoinTest {
 
         StreamExpression expression =
             InnerJoin.innerJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/InnerJoinTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.innerJoin;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
@@ -24,7 +23,7 @@ class InnerJoinTest {
             ")";
 
         StreamExpression expression =
-            innerJoin(
+            InnerJoin.innerJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
@@ -43,7 +42,7 @@ class InnerJoinTest {
             ")";
 
         StreamExpression expression =
-            innerJoin(
+            InnerJoin.innerJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/IntersectTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/IntersectTest.java
@@ -6,8 +6,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,8 @@ class IntersectTest {
 
         StreamExpression expression =
             Intersect.intersect(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
             );
         
@@ -43,8 +44,8 @@ class IntersectTest {
 
         StreamExpression expression =
             Intersect.intersect(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/IntersectTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/IntersectTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.intersect;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
@@ -24,7 +23,7 @@ class IntersectTest {
             ")";
 
         StreamExpression expression =
-            intersect(
+            Intersect.intersect(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
@@ -43,7 +42,7 @@ class IntersectTest {
             ")";
 
         StreamExpression expression =
-            intersect(
+            Intersect.intersect(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoinTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.leftOuterJoin;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
@@ -24,7 +23,7 @@ class LeftOuterJoinTest {
             ")";
 
         StreamExpression expression =
-            leftOuterJoin(
+            LeftOuterJoin.leftOuterJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
@@ -43,7 +42,7 @@ class LeftOuterJoinTest {
             ")";
 
         StreamExpression expression =
-            leftOuterJoin(
+            LeftOuterJoin.leftOuterJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/LeftOuterJoinTest.java
@@ -6,8 +6,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,8 @@ class LeftOuterJoinTest {
 
         StreamExpression expression =
             LeftOuterJoin.leftOuterJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc")),
                 on("personId")
             );
         
@@ -43,8 +44,8 @@ class LeftOuterJoinTest {
 
         StreamExpression expression =
             LeftOuterJoin.leftOuterJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                Search.search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc")),
                 on("personId", "ownerId")
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ListTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ListTest.java
@@ -3,8 +3,9 @@ package com.github.thesench.solr.dsl.stream.expr.decorators;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -17,8 +18,8 @@ public class ListTest {
                 "search(collection2,q=\"*:*\",fl=\"id,prod_ss\",sort=\"id asc\"))";
         
         StreamExpression expression =
-        List.list(search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
-            search("collection2", q("*:*"), fl("id", "prod_ss"), sort("id asc")));
+        List.list(Search.search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+            Search.search("collection2", q("*:*"), fl("id", "prod_ss"), sort("id asc")));
         
         assertEquals(expected, expression.toString());
     }
@@ -33,11 +34,11 @@ public class ListTest {
                 "search(collection5,q=\"*:*\",fl=\"id,prod_ss\",sort=\"id asc\"))";
         
         StreamExpression expression =
-        List.list(search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
-            search("collection2", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
-            search("collection3", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
-            search("collection4", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
-            search("collection5", q("*:*"), fl("id", "prod_ss"), sort("id asc")));
+        List.list(Search.search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+            Search.search("collection2", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+            Search.search("collection3", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+            Search.search("collection4", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+            Search.search("collection5", q("*:*"), fl("id", "prod_ss"), sort("id asc")));
         
         assertEquals(expected, expression.toString());
     }

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ListTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ListTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.list;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
@@ -18,7 +17,7 @@ public class ListTest {
                 "search(collection2,q=\"*:*\",fl=\"id,prod_ss\",sort=\"id asc\"))";
         
         StreamExpression expression =
-        list(search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+        List.list(search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
             search("collection2", q("*:*"), fl("id", "prod_ss"), sort("id asc")));
         
         assertEquals(expected, expression.toString());
@@ -34,7 +33,7 @@ public class ListTest {
                 "search(collection5,q=\"*:*\",fl=\"id,prod_ss\",sort=\"id asc\"))";
         
         StreamExpression expression =
-        list(search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
+        List.list(search("collection1", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
             search("collection2", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
             search("collection3", q("*:*"), fl("id", "prod_ss"), sort("id asc")),
             search("collection4", q("*:*"), fl("id", "prod_ss"), sort("id asc")),

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoinTest.java
@@ -7,8 +7,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,8 @@ class OuterHashJoinTest {
 
         StreamExpression expression =
             OuterHashJoin.outerHashJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                hashed(search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc"))),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                hashed(Search.search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc"))),
                 on("personId")
             );
         
@@ -44,8 +45,8 @@ class OuterHashJoinTest {
 
         StreamExpression expression =
             OuterHashJoin.outerHashJoin(
-                search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
-                hashed(search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc"))),
+                Search.search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
+                hashed(Search.search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc"))),
                 on("personId", "ownerId")
             );
         

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoinTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/OuterHashJoinTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.outerHashJoin;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.Hashed.hashed;
@@ -25,7 +24,7 @@ class OuterHashJoinTest {
             ")";
 
         StreamExpression expression =
-            outerHashJoin(
+            OuterHashJoin.outerHashJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 hashed(search("pets", q("type:cat"), qt(EXPORT), fl("personId,petName"), sort("personId asc"))),
                 on("personId")
@@ -44,7 +43,7 @@ class OuterHashJoinTest {
             ")";
 
         StreamExpression expression =
-            outerHashJoin(
+            OuterHashJoin.outerHashJoin(
                 search("people", q("*:*"), qt(EXPORT), fl("personId,name"), sort("personId asc")),
                 hashed(search("pets", q("type:cat"), qt(EXPORT), fl("ownerId,petName"), sort("ownerId asc"))),
                 on("personId", "ownerId")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ReduceTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/ReduceTest.java
@@ -9,8 +9,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.N.n;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ public class ReduceTest {
 
         StreamExpression expression =
             reduce(
-                search("collection1", q("*:*"), qt(EXPORT), fl("id", "a_s", "a_i", "a_f"), sort("a_s asc", "a_f asc")),
+                Search.search("collection1", q("*:*"), qt(EXPORT), fl("id", "a_s", "a_i", "a_f"), sort("a_s asc", "a_f asc")),
                 by("a_s"),
                 group(sort("a_f desc"), n(4))
             );

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SelectTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SelectTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.select;
 import static com.github.thesench.solr.dsl.stream.expr.evaluators.Add.add;
 import static com.github.thesench.solr.dsl.stream.expr.evaluators.Div.div;
 import static com.github.thesench.solr.dsl.stream.expr.evaluators.Eq.eq;
@@ -36,7 +35,7 @@ public class SelectTest {
             ")";
         
         StreamExpression expression =
-            select(
+            Select.select(
                 search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
                 "teamName_s as teamName",
                 "wins",
@@ -66,7 +65,7 @@ public class SelectTest {
             ")";
         
         StreamExpression expression =
-            select(
+            Select.select(
                 search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
                 teamName_s.as("teamName"),
                 wins,

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SelectTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SelectTest.java
@@ -11,10 +11,10 @@ import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.thesench.solr.dsl.stream.expr.params.Field;
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -36,7 +36,7 @@ public class SelectTest {
         
         StreamExpression expression =
             Select.select(
-                search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
+                Search.search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
                 "teamName_s as teamName",
                 "wins",
                 "losses",
@@ -66,7 +66,7 @@ public class SelectTest {
         
         StreamExpression expression =
             Select.select(
-                search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
+                Search.search("collection1", fl("id", "teamName_s", "wins", "losses"), q("*:*"), qt(EXPORT), sort("id asc")),
                 teamName_s.as("teamName"),
                 wins,
                 losses,

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.sort;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.By.by;
 import static com.github.thesench.solr.dsl.stream.expr.params.FL.fl;
@@ -29,7 +28,7 @@ public class SortTest {
             ")";
         
         StreamExpression expression =
-            sort(
+            Sort.sort(
                 InnerJoin.innerJoin(
                     search("people", q("*:*"), qt(EXPORT), fl("id", "name"), sort("id asc")),
                     search("pets", q("type:dog"), qt(EXPORT), fl("owner", "petName"), sort("owner asc")),

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
@@ -1,6 +1,5 @@
 package com.github.thesench.solr.dsl.stream.expr.decorators;
 
-import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.innerJoin;
 import static com.github.thesench.solr.dsl.stream.expr.decorators.StreamDecorators.sort;
 import static com.github.thesench.solr.dsl.stream.expr.params.RequestHandler.EXPORT;
 import static com.github.thesench.solr.dsl.stream.expr.params.By.by;
@@ -31,7 +30,7 @@ public class SortTest {
         
         StreamExpression expression =
             sort(
-                innerJoin(
+                InnerJoin.innerJoin(
                     search("people", q("*:*"), qt(EXPORT), fl("id", "name"), sort("id asc")),
                     search("pets", q("type:dog"), qt(EXPORT), fl("owner", "petName"), sort("owner asc")),
                     on("id", "owner")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/SortTest.java
@@ -7,8 +7,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.On.on;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -30,8 +31,8 @@ public class SortTest {
         StreamExpression expression =
             Sort.sort(
                 InnerJoin.innerJoin(
-                    search("people", q("*:*"), qt(EXPORT), fl("id", "name"), sort("id asc")),
-                    search("pets", q("type:dog"), qt(EXPORT), fl("owner", "petName"), sort("owner asc")),
+                    Search.search("people", q("*:*"), qt(EXPORT), fl("id", "name"), sort("id asc")),
+                    Search.search("pets", q("type:dog"), qt(EXPORT), fl("owner", "petName"), sort("owner asc")),
                     on("id", "owner")
                 ),
                 by("name asc", "petName asc")

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/TopTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/decorators/TopTest.java
@@ -7,8 +7,9 @@ import static com.github.thesench.solr.dsl.stream.expr.params.N.n;
 import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.thesench.solr.dsl.stream.expr.sources.Search;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ public class TopTest {
         
         StreamExpression expression =
             top(n(3),
-                search("collection1",
+                Search.search("collection1",
                     q("*:*"),
                     qt(EXPORT),
                     fl("id", "a_s", "a_i", "a_f"),

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/evaluators/AbsTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/evaluators/AbsTest.java
@@ -1,7 +1,7 @@
 package com.github.thesench.solr.dsl.stream.expr.evaluators;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static com.github.thesench.solr.dsl.stream.expr.evaluators.StreamEvaluators.abs;
+import static com.github.thesench.solr.dsl.stream.expr.evaluators.Abs.abs;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/thesench/solr/dsl/stream/expr/sources/SearchTest.java
+++ b/src/test/java/com/github/thesench/solr/dsl/stream/expr/sources/SearchTest.java
@@ -9,7 +9,6 @@ import static com.github.thesench.solr.dsl.stream.expr.params.Q.q;
 import static com.github.thesench.solr.dsl.stream.expr.params.QT.qt;
 import static com.github.thesench.solr.dsl.stream.expr.params.Rows.rows;
 import static com.github.thesench.solr.dsl.stream.expr.params.Sort.sort;
-import static com.github.thesench.solr.dsl.stream.expr.sources.StreamSources.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
@@ -18,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class SearchTest {
     @Test
     void search_withOnlyCollection() {
-        StreamExpression expression = search("someCollection");
+        StreamExpression expression = Search.search("someCollection");
 
         assertEquals("search(someCollection)", expression.toString());
     }
@@ -36,7 +35,7 @@ public class SearchTest {
             ")";
 
         StreamExpression expression =
-            search(
+            Search.search(
                 "someCollection",
                 q("someField:someValue"),
                 fl("field1", "field2", "field3 as someAlias"),


### PR DESCRIPTION
This PR moves each _implemented_ decorator/evaluator out into its own dedicated class.  This is being done to avoid having massive classes full of buckets of unrelated static factories.  This will unfortunately make discoverability a bit lower, as we can no longer simply tell IDE's like VSCode to "favorite" a few specific classes, but hopefully this will be mitigated by using names that make it fairly intuitive to find where specific stream methods can be found.